### PR TITLE
KieRepositoryLists: Use branch namespace due to conflicting branch names across multiple repositories

### DIFF
--- a/src/main/java/org/kie/jenkinsci/plugins/kieprbuildshelper/DownstreamReposBuilder.java
+++ b/src/main/java/org/kie/jenkinsci/plugins/kieprbuildshelper/DownstreamReposBuilder.java
@@ -102,7 +102,9 @@ public class DownstreamReposBuilder extends Builder {
             initFromEnvVars(envVars);
             FilePath workspace = build.getWorkspace();
 
-            GitHubRepositoryList kieRepoList = KieRepositoryLists.getListForBranch(prTargetBranch);
+            String repository = GitHubUtils.extractRepositoryName(prLink);
+            GitHubRepositoryList kieRepoList = KieRepositoryLists.getListForBranch(repository,
+                                                                                   prTargetBranch);
 
             KiePRBuildsHelper.KiePRBuildsHelperDescriptor globalSettings = KiePRBuildsHelper.getKiePRBuildsHelperDescriptor();
 

--- a/src/main/java/org/kie/jenkinsci/plugins/kieprbuildshelper/GitHubUtils.java
+++ b/src/main/java/org/kie/jenkinsci/plugins/kieprbuildshelper/GitHubUtils.java
@@ -32,10 +32,14 @@ import java.io.PrintStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class GitHubUtils {
 
     public static final File GIT_REFERENCE_BASEDIR = new File("/home/jenkins/git-repos/");
+
+    public static final Pattern GITHUB_PR_URL_PATTERN = Pattern.compile("\\w+://github.com/.+/(.+)/pull/\\d+");
 
     public static List<GHPullRequest> getOpenPullRequests(GitHubRepository repo, GitHub github) {
         try {
@@ -110,5 +114,19 @@ public class GitHubUtils {
         } else {
             buildLogger.println("No required GitHub repositories found.");
         }
+    }
+
+    public static String extractRepositoryName(String prLink) {
+        if (prLink == null) {
+            throw new IllegalArgumentException("Supplied PR link is null");
+        }
+
+        Matcher matcher = GITHUB_PR_URL_PATTERN.matcher(prLink);
+
+        while (matcher.find()) {
+            return matcher.group(1);
+        }
+
+        throw new IllegalArgumentException("Supplied PR link '" + prLink + "' does not match expected pattern " + GITHUB_PR_URL_PATTERN );
     }
 }

--- a/src/main/java/org/kie/jenkinsci/plugins/kieprbuildshelper/KieRepositoryLists.java
+++ b/src/main/java/org/kie/jenkinsci/plugins/kieprbuildshelper/KieRepositoryLists.java
@@ -24,37 +24,52 @@ import org.apache.commons.io.IOUtils;
 
 public class KieRepositoryLists {
 
-    public static GitHubRepositoryList getListForBranch(String branch) {
+    public static GitHubRepositoryList getListForBranch(final String repository,
+                                                        final String branch) {
+        String namespacedBranchId = resolveRepositoryNamespace(repository) + ":" + branch;
+
         List<KieGitHubRepository> repos = new ArrayList<KieGitHubRepository>();
-        switch (branch) {
-            case "master":
+
+        if ("master".equals(branch)) {
+            repos.add(new KieGitHubRepository("errai", "errai"));
+            repos.add(new KieGitHubRepository("uberfire", "uberfire"));
+            repos.add(new KieGitHubRepository("dashbuilder", "dashbuilder"));
+            repos.addAll(fetchRepositoryList("kiegroup", "master"));
+
+            return new GitHubRepositoryList(repos);
+        }
+
+        switch (namespacedBranchId) {
+            case "kiegroup:7.3.x": // kiegroup branch
+            case "dashbuilder:0.9.x": // dashbuilder branch
+            case "uberfire:1.3.x": // uberfire branch
                 repos.add(new KieGitHubRepository("errai", "errai"));
                 repos.add(new KieGitHubRepository("uberfire", "uberfire"));
                 repos.add(new KieGitHubRepository("dashbuilder", "dashbuilder"));
-                repos.addAll(fetchRepositoryList("kiegroup", "master"));
+                repos.addAll(fetchRepositoryList("kiegroup", "7.3.x"));
                 break;
 
-            case "7.2.x": // kiegroup branch
-            case "0.8.x": // dashbuilder branch
-            case "1.2.x": // uberfire branch
+            case "kiegroup:7.2.x": // kiegroup branch
+            case "dashbuilder:0.8.x": // dashbuilder branch
+            case "uberfire:1.2.x": // uberfire branch
                 repos.add(new KieGitHubRepository("errai", "errai"));
                 repos.add(new KieGitHubRepository("uberfire", "uberfire"));
                 repos.add(new KieGitHubRepository("dashbuilder", "dashbuilder"));
                 repos.addAll(fetchRepositoryList("kiegroup", "7.2.x"));
                 break;
 
-            case "7.0.x": // kiegroup branch
-            case "0.6.x": // dashbuilder branch
-            case "1.0.x": // uberfire branch
+            case "kiegroup:7.0.x": // kiegroup branch
+            case "dashbuilder:0.6.x": // dashbuilder branch
+            case "uberfire:1.0.x": // uberfire branch
                 repos.add(new KieGitHubRepository("errai", "errai"));
                 repos.add(new KieGitHubRepository("uberfire", "uberfire"));
                 repos.add(new KieGitHubRepository("dashbuilder", "dashbuilder"));
                 repos.addAll(fetchRepositoryList("kiegroup", "7.0.x"));
                 break;
 
-            case "6.5.x": // kiegroup branch
-            case "0.5.x": // dashbuilder branch
-            case "0.9.x": // uberfire branch
+            case "kiegroup:6.5.x": // kiegroup branch
+            case "dashbuilder:0.5.x": // dashbuilder branch
+            case "uberfire:0.9.x": // uberfire branch
                 repos.add(new KieGitHubRepository("uberfire", "uberfire"));
                 repos.add(new KieGitHubRepository("uberfire", "uberfire-extensions"));
                 repos.add(new KieGitHubRepository("dashbuilder", "dashbuilder"));
@@ -67,12 +82,20 @@ public class KieRepositoryLists {
         return new GitHubRepositoryList(repos);
     }
 
+    private static String resolveRepositoryNamespace(final String repository) {
+        if (isErraiRepo(repository) || isUberFireRepo(repository) || isDashbuilderRepo(repository)) {
+            return repository;
+        }
+        return "kiegroup";
+    }
+
     private static final List<BranchMapping> BRANCH_MAPPINGS = initMappings();
 
     private static List<BranchMapping> initMappings() {
         List<BranchMapping> mappings = new ArrayList<>();
         // branches for errai, uf, dashbuilder, kie
         mappings.add(new BranchMapping("master", "master", "master", "master"));
+        mappings.add(new BranchMapping("4.0.x", "1.3.x", "0.9.x", "7.3.x"));
         mappings.add(new BranchMapping("4.0.x", "1.2.x", "0.8.x", "7.2.x"));
         mappings.add(new BranchMapping("4.0.x", "1.0.x", "0.6.x", "7.0.x"));
         mappings.add(new BranchMapping("3.2", "0.9.x", "0.5.x", "6.5.x"));

--- a/src/main/java/org/kie/jenkinsci/plugins/kieprbuildshelper/StandardBuildUpstreamReposBuilder.java
+++ b/src/main/java/org/kie/jenkinsci/plugins/kieprbuildshelper/StandardBuildUpstreamReposBuilder.java
@@ -67,7 +67,8 @@ public class StandardBuildUpstreamReposBuilder extends Builder {
 
             FilePath workspace = build.getWorkspace();
 
-            GitHubRepositoryList kieRepoList = KieRepositoryLists.getListForBranch(branch);
+            GitHubRepositoryList kieRepoList = KieRepositoryLists.getListForBranch(baseRepository,
+                                                                                   branch);
             FilePath upstreamReposDir = new FilePath(workspace, "upstream-repos");
             // clean-up the destination directory to avoid stale content
             buildLogger.println("Cleaning-up directory " + upstreamReposDir.getRemote());

--- a/src/main/java/org/kie/jenkinsci/plugins/kieprbuildshelper/UpstreamReposBuilder.java
+++ b/src/main/java/org/kie/jenkinsci/plugins/kieprbuildshelper/UpstreamReposBuilder.java
@@ -104,7 +104,8 @@ public class UpstreamReposBuilder extends Builder {
             GitHubPRSummary prSummary = GitHubPRSummary.fromPRLink(prLink, github);
 
             String prRepoName = prSummary.getTargetRepoName();
-            GitHubRepositoryList kieRepoList = KieRepositoryLists.getListForBranch(prTargetBranch);
+            GitHubRepositoryList kieRepoList = KieRepositoryLists.getListForBranch(prRepoName,
+                                                                                   prTargetBranch);
             kieRepoList.filterOutUnnecessaryUpstreamRepos(prRepoName);
             Map<KieGitHubRepository, RefSpec> upstreamRepos =
                     gatherUpstreamReposToBuild(prRepoName, prSourceBranch, prTargetBranch, prSummary.getSourceRepoOwner(), kieRepoList, github);

--- a/src/test/java/org/kie/jenkinsci/plugins/kieprbuildshelper/GitHubRepositoryListTest.java
+++ b/src/test/java/org/kie/jenkinsci/plugins/kieprbuildshelper/GitHubRepositoryListTest.java
@@ -24,7 +24,8 @@ public class GitHubRepositoryListTest {
 
     @Test
     public void shouldFilterOutUFAndDashbuilderReposForDroolsRepo() {
-        GitHubRepositoryList ghList = KieRepositoryLists.getListForBranch("master");
+        GitHubRepositoryList ghList = KieRepositoryLists.getListForBranch("drools",
+                                                                          "master");
         ghList.filterOutUnnecessaryUpstreamRepos("drools");
         assertFalse(ghList.contains(new KieGitHubRepository("errai", "errai")));
         assertFalse(ghList.contains(new KieGitHubRepository("uberfire", "uberfire")));
@@ -36,7 +37,8 @@ public class GitHubRepositoryListTest {
 
     @Test
     public void shouldNotFilterOutErraiAndUFAndDashbuilderReposForDroolsjbpmIntegrationRepo() {
-        GitHubRepositoryList ghList = KieRepositoryLists.getListForBranch("master");
+        GitHubRepositoryList ghList = KieRepositoryLists.getListForBranch("droolsjbpm-integration",
+                                                                          "master");
         ghList.filterOutUnnecessaryUpstreamRepos("droolsjbpm-integration");
         assertTrue(ghList.contains(new KieGitHubRepository("errai", "errai")));
         assertTrue(ghList.contains(new KieGitHubRepository("uberfire", "uberfire")));

--- a/src/test/java/org/kie/jenkinsci/plugins/kieprbuildshelper/GitHubUtilsTest.java
+++ b/src/test/java/org/kie/jenkinsci/plugins/kieprbuildshelper/GitHubUtilsTest.java
@@ -1,0 +1,20 @@
+package org.kie.jenkinsci.plugins.kieprbuildshelper;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GitHubUtilsTest {
+
+    @Test
+    public void extractRepositoryName() {
+        String result = GitHubUtils.extractRepositoryName("https://github.com/kiegroup/optaplanner-wb/pull/198");
+
+        assertEquals("optaplanner-wb", result);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void extractRepositoryNameWrongUrl() {
+        GitHubUtils.extractRepositoryName("https://wrong/url/pull/125");
+    }
+}

--- a/src/test/java/org/kie/jenkinsci/plugins/kieprbuildshelper/KieGithubRepositoryBaseBranchTest.java
+++ b/src/test/java/org/kie/jenkinsci/plugins/kieprbuildshelper/KieGithubRepositoryBaseBranchTest.java
@@ -39,6 +39,14 @@ public class KieGithubRepositoryBaseBranchTest {
                 {new KieGitHubRepository("uberfire", "uberfire"), "guvnor", "master", "master"},
                 {new KieGitHubRepository("dashbuilder", "dashbuilder"), "guvnor", "master", "master"},
                 {new KieGitHubRepository("kiegroup", "guvnor"), "jbpm-wb", "master", "master"},
+                // upstream repo builds, 7.3.x branch
+                {new KieGitHubRepository("errai", "errai"), "uberfire", "1.3.x", "4.0.x"},
+                {new KieGitHubRepository("errai", "errai"), "dashbuilder", "0.9.x", "4.0.x"},
+                {new KieGitHubRepository("errai", "errai"), "guvnor", "7.3.x", "4.0.x"},
+                {new KieGitHubRepository("uberfire", "uberfire"), "dashbuilder", "0.9.x", "1.3.x"},
+                {new KieGitHubRepository("uberfire", "uberfire"), "guvnor", "7.3.x", "1.3.x"},
+                {new KieGitHubRepository("dashbuilder", "dashbuilder"), "guvnor", "7.3.x", "0.9.x"},
+                {new KieGitHubRepository("kiegroup", "guvnor"), "jbpm-wb", "7.3.x", "7.3.x"},
                 // upstream repo builds, 7.2.x branch
                 {new KieGitHubRepository("errai", "errai"), "uberfire", "1.2.x", "4.0.x"},
                 {new KieGitHubRepository("errai", "errai"), "dashbuilder", "0.8.x", "4.0.x"},

--- a/src/test/java/org/kie/jenkinsci/plugins/kieprbuildshelper/KieRepositoryListsTest.java
+++ b/src/test/java/org/kie/jenkinsci/plugins/kieprbuildshelper/KieRepositoryListsTest.java
@@ -24,7 +24,8 @@ public class KieRepositoryListsTest {
 
     @Test
     public void fetchRepositoryListForMaster() {
-        List<KieGitHubRepository> kieRepos = KieRepositoryLists.getListForBranch("master").getList();
+        List<KieGitHubRepository> kieRepos = KieRepositoryLists.getListForBranch("drools",
+                                                                                 "master").getList();
         // don't do any specific assertions as the repo list may change at any time as the test would then start failing
         // at least the manually added errai, uf and dashbuilder repos need to present though
         Assertions.assertThat(kieRepos.size()).isGreaterThan(3);
@@ -37,7 +38,8 @@ public class KieRepositoryListsTest {
 
     @Test
     public void fetchRepositoryListFor65x() {
-        List<KieGitHubRepository> kieRepos = KieRepositoryLists.getListForBranch("6.5.x").getList();
+        List<KieGitHubRepository> kieRepos = KieRepositoryLists.getListForBranch("drools",
+                                                                                 "6.5.x").getList();
         // don't do any specific assertions as the repo list may change at any time as the test would then start failing
         // at least the manually added errai, uf and dashbuilder repos need to present though
         Assertions.assertThat(kieRepos.size()).isGreaterThan(3);
@@ -51,7 +53,8 @@ public class KieRepositoryListsTest {
 
     @Test (expected = IllegalArgumentException.class)
     public void fetchRepositoryListForUnknownBranch() {
-        KieRepositoryLists.getListForBranch("unknown-branch");
+        KieRepositoryLists.getListForBranch("drools",
+                                            "unknown-branch");
     }
 
     @Test(expected = RuntimeException.class)


### PR DESCRIPTION
@mbiarnes @psiroky This adds support for branch namespaces due to conflicting branch names across repositories (dashbuilder 0.9.x & uberfire 0.9.x in this case). Could you please review? Thanks 